### PR TITLE
Upgrade to Go1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ orbs:
 executors:
   golang:
     docker:
-      - image: cimg/go:1.15
+      - image: cimg/go:1.16
   machine:
     machine:
       image: ubuntu-1604:201903-01
@@ -65,10 +65,10 @@ commands:
   setup_go:
     steps:
       - run:
-          name: Install Go 1.15
+          name: Install Go 1.16
           command: |
             sudo rm -rf /usr/local/go
-            curl -L https://dl.google.com/go/go1.15.11.linux-amd64.tar.gz | sudo tar xz -C /usr/local
+            curl -L https://dl.google.com/go/go1.16.11.linux-amd64.tar.gz | sudo tar xz -C /usr/local
       - run:
           name: Add ~/go/bin to PATH
           command: |
@@ -307,7 +307,7 @@ jobs:
 
   build-examples:
     docker:
-      - image: cimg/go:1.15
+      - image: cimg/go:1.16
     steps:
       - restore_workspace
       - setup_remote_docker
@@ -367,7 +367,7 @@ jobs:
       - run:
           name: Upgrade golang
           command: |
-            choco upgrade golang --version=1.15
+            choco upgrade golang --version=1.16
             refreshenv
       - run:
           name: Unit tests
@@ -400,7 +400,7 @@ jobs:
 
   publish-check:
     docker:
-      - image: cimg/go:1.15
+      - image: cimg/go:1.16
     steps:
       - attach_to_workspace
       - setup_remote_docker
@@ -416,7 +416,7 @@ jobs:
 
   publish-stable:
     docker:
-      - image: cimg/go:1.15
+      - image: cimg/go:1.16
     steps:
       - restore_workspace
       - verify_dist_files_exist

--- a/Makefile
+++ b/Makefile
@@ -146,15 +146,15 @@ $(MODULEDIRS):
 TOOLS_MOD_DIR := ./internal/tools
 .PHONY: install-tools
 install-tools:
-	cd $(TOOLS_MOD_DIR) && go install github.com/client9/misspell/cmd/misspell
-	cd $(TOOLS_MOD_DIR) && go install github.com/golangci/golangci-lint/cmd/golangci-lint
-	cd $(TOOLS_MOD_DIR) && go install github.com/google/addlicense
-	cd $(TOOLS_MOD_DIR) && go install github.com/jstemmer/go-junit-report
-	cd $(TOOLS_MOD_DIR) && go install github.com/pavius/impi/cmd/impi
-	cd $(TOOLS_MOD_DIR) && go install github.com/tcnksm/ghr
-	cd $(TOOLS_MOD_DIR) && go install go.opentelemetry.io/collector/cmd/checkdoc
-	cd $(TOOLS_MOD_DIR) && go install go.opentelemetry.io/collector/cmd/issuegenerator
-	cd $(TOOLS_MOD_DIR) && go install go.opentelemetry.io/collector/cmd/mdatagen
+	go install github.com/client9/misspell/cmd/misspell@v0.3.4
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.39.0
+	go install github.com/google/addlicense@v0.0.0-20200906110928-a0294312aa76
+	go install github.com/jstemmer/go-junit-report@v0.9.1
+	go install github.com/pavius/impi/cmd/impi@v0.0.3
+	go install github.com/tcnksm/ghr@v0.13.0
+	go install go.opentelemetry.io/collector/cmd/checkdoc@v0.25.1-0.20210421230708-d10b842f49eb
+	go install go.opentelemetry.io/collector/cmd/issuegenerator@v0.25.1-0.20210421230708-d10b842f49eb
+	go install go.opentelemetry.io/collector/cmd/mdatagen@v0.25.1-0.20210421230708-d10b842f49eb
 
 .PHONY: run
 run:

--- a/exporter/alibabacloudlogserviceexporter/go.mod
+++ b/exporter/alibabacloudlogserviceexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/aliyun/aliyun-log-go-sdk v0.1.20

--- a/exporter/awsemfexporter/go.mod
+++ b/exporter/awsemfexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.38.21

--- a/exporter/awskinesisexporter/go.mod
+++ b/exporter/awskinesisexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/exporter/awsprometheusremotewriteexporter/go.mod
+++ b/exporter/awsprometheusremotewriteexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsprometheusremotewriteexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/exporter/awsxrayexporter/go.mod
+++ b/exporter/awsxrayexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/exporter/azuremonitorexporter/go.mod
+++ b/exporter/azuremonitorexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter
 
-go 1.15
+go 1.16
 
 require (
 	code.cloudfoundry.org/clock v1.0.0 // indirect

--- a/exporter/carbonexporter/go.mod
+++ b/exporter/carbonexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/DataDog/datadog-agent/pkg/trace/exportable v0.0.0-20201016145401-4646cf596b02

--- a/exporter/dynatraceexporter/go.mod
+++ b/exporter/dynatraceexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dynatraceexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/exporter/elasticexporter/go.mod
+++ b/exporter/elasticexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/exporter/elasticsearchexporter/go.mod
+++ b/exporter/elasticsearchexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/exporter/f5cloudexporter/go.mod
+++ b/exporter/f5cloudexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/f5cloudexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/exporter/googlecloudexporter/go.mod
+++ b/exporter/googlecloudexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter
 
-go 1.15
+go 1.16
 
 require (
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.5

--- a/exporter/honeycombexporter/go.mod
+++ b/exporter/honeycombexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/exporter/humioexporter/go.mod
+++ b/exporter/humioexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/humioexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/stretchr/testify v1.7.0

--- a/exporter/jaegerthrifthttpexporter/go.mod
+++ b/exporter/jaegerthrifthttpexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerthrifthttpexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/apache/thrift v0.13.0

--- a/exporter/loadbalancingexporter/go.mod
+++ b/exporter/loadbalancingexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.0.0-00010101000000-000000000000

--- a/exporter/logzioexporter/go.mod
+++ b/exporter/logzioexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/exporter/lokiexporter/go.mod
+++ b/exporter/lokiexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/exporter/newrelicexporter/go.mod
+++ b/exporter/newrelicexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/newrelicexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/exporter/sapmexporter/go.mod
+++ b/exporter/sapmexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/jaegertracing/jaeger v1.22.0

--- a/exporter/sentryexporter/go.mod
+++ b/exporter/sentryexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/exporter/signalfxexporter/go.mod
+++ b/exporter/signalfxexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0

--- a/exporter/splunkhecexporter/go.mod
+++ b/exporter/splunkhecexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0

--- a/exporter/sumologicexporter/go.mod
+++ b/exporter/sumologicexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/exporter/uptraceexporter/go.mod
+++ b/exporter/uptraceexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/uptraceexporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/extension/fluentbitextension/go.mod
+++ b/extension/fluentbitextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/fluentbitextension
 
-go 1.15
+go 1.16
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/extension/httpforwarder/go.mod
+++ b/extension/httpforwarder/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarder
 
-go 1.15
+go 1.16
 
 require (
 	github.com/pelletier/go-toml v1.8.0 // indirect

--- a/extension/observer/ecsobserver/go.mod
+++ b/extension/observer/ecsobserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.38.21

--- a/extension/observer/go.mod
+++ b/extension/observer/go.mod
@@ -1,5 +1,5 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer
 
-go 1.15
+go 1.16
 
 require github.com/stretchr/testify v1.7.0

--- a/extension/observer/hostobserver/go.mod
+++ b/extension/observer/hostobserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/extension/observer/k8sobserver/go.mod
+++ b/extension/observer/k8sobserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/extension/storage/go.mod
+++ b/extension/storage/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage
 
-go 1.15
+go 1.16
 
 require (
 	github.com/stretchr/testify v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib
 
-go 1.15
+go 1.16
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.0.0-00010101000000-000000000000

--- a/internal/aws/metrics/go.mod
+++ b/internal/aws/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics
 
-go 1.15
+go 1.16
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/internal/aws/xray/go.mod
+++ b/internal/aws/xray/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray
 
-go 1.15
+go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.38.21

--- a/internal/aws/xray/testdata/sampleapp/go.mod
+++ b/internal/aws/xray/testdata/sampleapp/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver/testdata/rawsegment/sampleapp
 
-go 1.15
+go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.38.21

--- a/internal/aws/xray/testdata/sampleserver/go.mod
+++ b/internal/aws/xray/testdata/sampleserver/go.mod
@@ -1,5 +1,5 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver/testdata/rawsegment/sampleserver
 
-go 1.15
+go 1.16
 
 require github.com/aws/aws-xray-sdk-go v1.3.0

--- a/internal/common/go.mod
+++ b/internal/common/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/common
 
-go 1.15
+go 1.16
 
 require (
 	github.com/Microsoft/go-winio v0.4.16 // indirect

--- a/internal/k8sconfig/go.mod
+++ b/internal/k8sconfig/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig
 
-go 1.15
+go 1.16
 
 require (
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/internal/splunk/go.mod
+++ b/internal/splunk/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk
 
-go 1.15
+go 1.16
 
 require (
 	github.com/pelletier/go-toml v1.8.0 // indirect

--- a/internal/stanza/go.mod
+++ b/internal/stanza/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/stanza
 
-go 1.15
+go 1.16
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.0.0-20210403015025-665fae9cf30e

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/tools
 
-go 1.15
+go 1.16
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/pkg/batchperresourceattr/go.mod
+++ b/pkg/batchperresourceattr/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr
 
-go 1.15
+go 1.16
 
 require (
 	github.com/stretchr/testify v1.7.0

--- a/pkg/batchpersignal/go.mod
+++ b/pkg/batchpersignal/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal
 
-go 1.15
+go 1.16
 
 require (
 	github.com/stretchr/testify v1.7.0

--- a/pkg/batchpertrace/go.mod
+++ b/pkg/batchpertrace/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpertrace
 
-go 1.15
+go 1.16
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.0.0-00010101000000-000000000000

--- a/pkg/experimentalmetricmetadata/go.mod
+++ b/pkg/experimentalmetricmetadata/go.mod
@@ -1,5 +1,5 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata
 
-go 1.15
+go 1.16
 
 require github.com/stretchr/testify v1.7.0

--- a/processor/groupbyattrsprocessor/go.mod
+++ b/processor/groupbyattrsprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/processor/groupbytraceprocessor/go.mod
+++ b/processor/groupbytraceprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
 
-go 1.15
+go 1.16
 
 require (
 	github.com/pelletier/go-toml v1.8.0 // indirect

--- a/processor/k8sprocessor/go.mod
+++ b/processor/k8sprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sprocessor
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/processor/metricstransformprocessor/go.mod
+++ b/processor/metricstransformprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/processor/resourcedetectionprocessor/go.mod
+++ b/processor/resourcedetectionprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
 
-go 1.15
+go 1.16
 
 require (
 	cloud.google.com/go v0.81.0

--- a/processor/routingprocessor/go.mod
+++ b/processor/routingprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/processor/spanmetricsprocessor/go.mod
+++ b/processor/spanmetricsprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/processor/tailsamplingprocessor/go.mod
+++ b/processor/tailsamplingprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/receiver/awsecscontainermetricsreceiver/go.mod
+++ b/receiver/awsecscontainermetricsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/receiver/awsxrayreceiver/go.mod
+++ b/receiver/awsxrayreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/receiver/carbonreceiver/go.mod
+++ b/receiver/carbonreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/receiver/collectdreceiver/go.mod
+++ b/receiver/collectdreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/receiver/dockerstatsreceiver/go.mod
+++ b/receiver/dockerstatsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0

--- a/receiver/dotnetdiagnosticsreceiver/go.mod
+++ b/receiver/dotnetdiagnosticsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/receiver/filelogreceiver/go.mod
+++ b/receiver/filelogreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/observiq/nanojack v0.0.0-20201106172433-343928847ebc

--- a/receiver/fluentforwardreceiver/go.mod
+++ b/receiver/fluentforwardreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/stretchr/testify v1.7.0

--- a/receiver/jmxreceiver/go.mod
+++ b/receiver/jmxreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/receiver/k8sclusterreceiver/go.mod
+++ b/receiver/k8sclusterreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0

--- a/receiver/kafkametricsreceiver/go.mod
+++ b/receiver/kafkametricsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/Shopify/sarama v1.28.0

--- a/receiver/kubeletstatsreceiver/go.mod
+++ b/receiver/kubeletstatsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0

--- a/receiver/memcachedreceiver/go.mod
+++ b/receiver/memcachedreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/receiver/nginxreceiver/go.mod
+++ b/receiver/nginxreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/receiver/prometheusexecreceiver/go.mod
+++ b/receiver/prometheusexecreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusexecreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/receiver/receivercreator/go.mod
+++ b/receiver/receivercreator/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator
 
-go 1.15
+go 1.16
 
 require (
 	github.com/antonmedv/expr v1.8.9

--- a/receiver/redisreceiver/go.mod
+++ b/receiver/redisreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/go-redis/redis/v7 v7.4.0

--- a/receiver/sapmreceiver/go.mod
+++ b/receiver/sapmreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/gorilla/mux v1.8.0

--- a/receiver/signalfxreceiver/go.mod
+++ b/receiver/signalfxreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/gorilla/mux v1.8.0

--- a/receiver/simpleprometheusreceiver/examples/federation/prom-counter/go.mod
+++ b/receiver/simpleprometheusreceiver/examples/federation/prom-counter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver/examples/federation/prom-counter
 
-go 1.15
+go 1.16
 
 require (
 	go.opentelemetry.io/otel v0.19.0

--- a/receiver/simpleprometheusreceiver/go.mod
+++ b/receiver/simpleprometheusreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/receiver/splunkhecreceiver/go.mod
+++ b/receiver/splunkhecreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/gobwas/glob v0.2.3

--- a/receiver/statsdreceiver/go.mod
+++ b/receiver/statsdreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/receiver/syslogreceiver/go.mod
+++ b/receiver/syslogreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/stanza v0.0.0-00010101000000-000000000000

--- a/receiver/wavefrontreceiver/go.mod
+++ b/receiver/wavefrontreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0

--- a/receiver/windowsperfcountersreceiver/go.mod
+++ b/receiver/windowsperfcountersreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/receiver/zookeeperreceiver/go.mod
+++ b/receiver/zookeeperreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/testbed
 
-go 1.15
+go 1.16
 
 require (
 	github.com/fluent/fluent-logger-golang v1.5.0

--- a/testbed/mockdatareceivers/mockawsxrayreceiver/go.mod
+++ b/testbed/mockdatareceivers/mockawsxrayreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/testbed/mockdatareceivers/mockawsxrayreceiver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/gorilla/mux v1.8.0

--- a/tracegen/go.mod
+++ b/tracegen/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/tracegen
 
-go 1.15
+go 1.16
 
 require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2


### PR DESCRIPTION
**Description:** 

Updated CI and makefile to use Go 1.16.

In 1.16, `go install` accepts versions so the tools trick to pin tool versions is not required anymore.